### PR TITLE
feat: initial implementation of the `Vec<T, A: Allocator>` type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 Cargo.lock
 **/*.rs.bk
 *.pdb
+tarpaulin-report.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,3 @@ no_std = ["hashbrown"]
 
 [dependencies]
 hashbrown = { version = "0.14", optional = true }
-
-[build-dependencies]
-rustc_version = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,5 @@ no_std = ["hashbrown"]
 [dependencies]
 hashbrown = { version = "0.14", optional = true }
 
-[dev-dependencies]
-libc-print = "0.1.23"
-
 [build-dependencies]
 rustc_version = "0.4.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(feature = "no_std", no_std)]
 #![feature(allocator_api)]
 
 extern crate alloc;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -48,6 +48,7 @@ mod tests {
     use super::*;
     use alloc::alloc::Global;
     use alloc::collections::TryReserveError;
+    use alloc::format;
     use alloc::sync::Arc;
     use core::alloc::{AllocError, Layout};
     use core::ptr::NonNull;
@@ -114,5 +115,26 @@ mod tests {
         assert_eq!(vec.inner.capacity(), 4);
 
         let _err: TryReserveError = Vec::<i8, _>::with_capacity_in(5, wma).unwrap_err();
+    }
+
+    #[test]
+    fn test_reserve() {
+        let wma = WatermarkAllocator::new(32);
+        let mut vec: Vec<bool, _> = Vec::new_in(wma);
+        vec.reserve(32).unwrap();
+        assert_eq!(vec.inner.capacity(), 32);
+
+        let _err: TryReserveError = vec.reserve(33).unwrap_err();
+    }
+
+    #[test]
+    fn test_fmt_debug() {
+        let wma = WatermarkAllocator::new(32);
+        let mut vec = Vec::new_in(wma);
+        vec.try_push(1).unwrap();
+        vec.try_push(2).unwrap();
+        vec.try_push(3).unwrap();
+        vec.try_push(4).unwrap();
+        assert_eq!(format!("{:?}", vec), "[1, 2, 3, 4]");
     }
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -18,6 +18,11 @@ impl<T, A: Allocator> Vec<T, A> {
     }
 
     #[inline]
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    #[inline]
     pub fn reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.inner.try_reserve(additional)
     }
@@ -63,6 +68,11 @@ impl<T, A: Allocator> Vec<T, A> {
     }
 
     #[inline]
+    pub fn as_slice(&self) -> &[T] {
+        self
+    }
+
+    #[inline]
     pub fn as_ptr(&self) -> *const T {
         self.inner.as_ptr()
     }
@@ -70,6 +80,11 @@ impl<T, A: Allocator> Vec<T, A> {
     #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut T {
         self.inner.as_mut_ptr()
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.inner.clear();
     }
 }
 
@@ -186,10 +201,11 @@ mod tests {
     }
 
     #[test]
-    fn test_push() {
+    fn test_basics() {
         let wma = WatermarkAllocator::new(32);
         let mut vec = Vec::new_in(wma);
         assert_eq!(vec.len(), 0);
+        assert_eq!(vec.capacity(), 0);
         assert!(vec.is_empty());
         vec.push(1).unwrap();
         assert_eq!(vec.len(), 1);
@@ -198,9 +214,14 @@ mod tests {
         vec.push(3).unwrap();
         vec.push(4).unwrap();
         assert_eq!(vec.len(), 4);
+        assert_eq!(vec.capacity(), 4);
         let _err: TryReserveError = vec.push(5).unwrap_err();
-        assert_eq!(vec.inner.as_slice(), &[1, 2, 3, 4]);
+        assert_eq!(vec.as_slice(), &[1, 2, 3, 4]);
         assert_eq!(vec.len(), 4);
+        vec.clear();
+        assert_eq!(vec.len(), 0);
+        assert!(vec.is_empty());
+        assert_eq!(vec.capacity(), 4);
     }
 
     #[test]


### PR DESCRIPTION
Initial implementation for the vector type.
A few basic methods that we'll surely end up needing.
This is _not_ intended to be a full mirror of the whole standard lib's `Vec` API.