### PR TITLE
Vec: removed Clone trait and introduced TryClone trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "alloc-checked"
 description = "Collections that don't panic on alloc failures"
 authors = ["Adam Cimarosti <adam@questdb.io>"]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 repository = "https://github.com/questdb/alloc-checked"
 keywords = ["alloc", "collections", "no-std", "safe-allocation", "container"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,5 @@
 extern crate alloc;
 extern crate core;
 
+pub mod try_clone;
 pub mod vec;

--- a/src/try_clone.rs
+++ b/src/try_clone.rs
@@ -1,0 +1,10 @@
+/// A variant of the `Clone` trait which can fail.
+pub trait TryClone: Sized {
+    type Error;
+
+    fn try_clone(&self) -> Result<Self, Self::Error>;
+    fn try_clone_from(&mut self, source: &Self) -> Result<(), Self::Error> {
+        *self = source.try_clone()?;
+        Ok(())
+    }
+}

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -186,7 +186,7 @@ impl<T: Clone, A: Allocator> Vec<T, A> {
     }
 }
 
-impl<T: Clone, A: Allocator + Clone> TryClone for Vec<T, A> {
+impl<T: Copy, A: Allocator + Clone> TryClone for Vec<T, A> {
     type Error = TryReserveError;
 
     fn try_clone(&self) -> Result<Self, Self::Error> {


### PR DESCRIPTION
This change drops support for the `Clone` trait, since that would have internally allocated and failed. It introduces a new `TryClone` in its place.

This issue was spotted here: https://www.reddit.com/r/rust/comments/1fy7cu8/comment/lqvd9me/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

This PR does not provide complete support for the `TryClone` trait. Some outstanding work is detailed here: https://github.com/questdb/alloc-checked/issues/7